### PR TITLE
bugfix: make Game.runAll() return total number of wins minus losses

### DIFF
--- a/Game.java
+++ b/Game.java
@@ -55,15 +55,7 @@ public class Game
         {
             sum += run(i) - 1;
         }
-        if(sum > 0)
-        {
-            return 1;
-        }
-        if(sum < 0)
-        {
-            return -1;
-        }
-        return 0;
+        return sum;
     }
     
     public int run()


### PR DESCRIPTION
While working on speeding up the game loop, I found what looks like a bug to me: when `repeats == 0`, the Tournament class calculates the match result (which, supposedly, should be based on the total number of player1 wins minus player2 wins) as `result = g.runAll() - g2.runAll();` (where `g` starts player1 first, and `g2` starts player2 first).  But `Game.runAll()` does _not_ actually return the number of player1 wins minus player2 wins, but merely its sign, skewing the results.

Here's a simple patch to fix this problem; hopefully, it should apply cleanly with or without the "save old match results" patch I submitted. (However, do note that this bugfix can change the match results, so you should delete savedresults.txt after applying it!)

Fortunately, this change does not seem to affect the actual rankings much.  Here's the [leaderboard](http://codegolf.stackexchange.com/questions/47581/the-nano-core-war) using this fix, as of 18 March, 0:40 UTC (including my DwarvenEngineer and the latest version of CopyPasta):

```
Leaderboard:
   16 - DwarvenEngineer                         
   14 - Dwarf                                   
   10 - ScanBomber                              
   10 - Evolved                                 
    8 - Janitor                                 
    6 - FirstTimer                              
    4 - CopyPasta                               
    2 - Imp                                     
    2 - Slug  
```
