### PR TITLE
Minor fixes to parser and debug output

### DIFF
--- a/Game.java
+++ b/Game.java
@@ -207,6 +207,7 @@ public class Game
             {
                 if(dupCount == 0)
                 {
+                    System.out.printf("%04d\t", i);
                     System.out.println(line);
                 }
                 dupCount++;
@@ -215,12 +216,14 @@ public class Game
             {
                 if(dupCount == 2)
                 {
+                    System.out.printf("%04d\t", i-1);
                     System.out.println(dupLine);
                 }
                 else if(dupCount > 2)
                 {
                     System.out.println("    " + (dupCount - 1) + " lines skipped.");
                 }
+                System.out.printf("%04d\t", i);
                 System.out.print(line);
                 if(i == ploc)
                 {
@@ -237,6 +240,7 @@ public class Game
         }
         if(dupCount == 2)
         {
+            System.out.printf("%04d\t", core.length-1);
             System.out.println(dupLine);
         }
         else if(dupCount > 2)

--- a/Parser.java
+++ b/Parser.java
@@ -57,8 +57,15 @@ public class Parser
             if(verbose) System.err.println(line);
             line = line.trim().replaceAll(","," ").replaceAll("\\s+", " ").toUpperCase();
             String[] fields = line.split(" ");
-            commands.add(new ArrayList<String>(Arrays.asList(line.split(" "))));
-            //System.err.println("Checkpoint 1");
+            if(fields.length == 3 || fields.length == 4)
+            {
+                commands.add(new ArrayList<String>(Arrays.asList(fields)));
+            }
+            else if(line.length() > 0)
+            {
+                System.err.println("Syntax error on line " + i + " in " + fileName + ": " + line);
+                return null;
+            }
         }
         //System.err.println("Checkpoint 2");
         for(int i = 0; i < commands.size(); i++)

--- a/Tournament.java
+++ b/Tournament.java
@@ -23,7 +23,7 @@ public class Tournament
     static int repeats = 0; //number of times a battle is played between each pair of contestants
     static int debug = 0;
     static int verbose = 0;
-    static int cache = 1;
+    static int cache = 2;
     
     static final String settingsFile = "settings.txt";
     static final String playerFile = "playerlist.txt";
@@ -134,7 +134,7 @@ public class Tournament
 
         try{
             PrintWriter saveResults = null;
-            if(cache > 0)
+            if(cache > 1)
             {
                 saveResults = new PrintWriter(new FileWriter(saveFile, true));  // append mode
             }
@@ -173,7 +173,7 @@ public class Tournament
                             Game g2 = new Game(p2, p1, coreSize, maxTime, debug);
                             result = g.runAll() - g2.runAll();
                         }
-                        if(cache > 0)
+                        if(saveResults != null)
                         {
                             String name1 = (hashOrder < 0 ? p1 : p2).getName();
                             String name2 = (hashOrder < 0 ? p2 : p1).getName();
@@ -199,7 +199,7 @@ public class Tournament
                     }
                 }
             }
-            if(cache > 0)
+            if(saveResults != null)
             {
                 saveResults.close();
             }

--- a/settings.txt
+++ b/settings.txt
@@ -1,6 +1,6 @@
 coresize  8192    -  Default is 8192.
 repeats      0    -  Number of times each matchup is played.  Set to 0 to run all unique starting configurations.  Default is 0.
-cache        1    -  turn to 0 to disable loading and saving of match results in savedresults.txt.  Default is 1.
+cache        2    -  controls loading and saving of match results in savedresults.txt (0 = do not load or save, 1 = load but don't save, 2 = load and save).  Default is 2.
 verbose      0    -  turn to 1 to print the original, preprocessed and compiled source of each program.  Default is 0.
 debug        0    -  turn to 1 to print a play-by-play of each battle.  You should decrease your core size and repeats first.  Default is 0.
 maxtime      8    -  The total time before a tie is declared is maxtime * coresize, with time measured in ply (1 move by 1 player equals 1 ply).  Default is 8.


### PR DESCRIPTION
Here's a couple of simple minor tweaks you might want to merge in:
- The patch the `Game.java` adds line numbers to the debug output; I found them useful for figuring out where everything is in the core.
- The `Parser.java` patch prevents a crash if the source code contains blank lines.
- The `Tournament.java` patch modifies the `cache` setting so that it's possible to load old match results but not save new ones (as requested by TheBestOne in chat).
