### PR TITLE
A few more minor fixes

### DIFF
--- a/Parser.java
+++ b/Parser.java
@@ -26,7 +26,7 @@ public class Parser
         put("JMZ",  Instruction.OP_JMZ);
         put("CMP",  Instruction.OP_CMP);
         put("COMPARE",  Instruction.OP_CMP);
-        put("SEQ",  Instruction.OP_CMP);
+        put("SNE",  Instruction.OP_CMP);
     }};
     public static int opEncode(String opcode)
     {

--- a/Tournament.java
+++ b/Tournament.java
@@ -155,11 +155,11 @@ public class Tournament
                         : hash2 + ":" + hash1);
                     
                     int result = 0;
-                    boolean cached = false;
+                    String newMarker = (cache > 0 ? " (new)" : "");
                     if(matchResults.containsKey(matchHash))
                     {
                         result = -hashOrder * matchResults.get(matchHash).intValue();
-                        cached = true;
+                        newMarker = "";
                     }
                     else
                     {
@@ -184,18 +184,18 @@ public class Tournament
                     if(result > repeats)
                     {
                         score.put(p1.getName(), score.get(p1.getName()) + 2);
-                        System.out.println(p1.getName() +" > "+ p2.getName() + (cached ? " (cached)" : ""));
+                        System.out.println(p1.getName() +" > "+ p2.getName() + newMarker);
                     }
                     else if(result < repeats)
                     {
                         score.put(p2.getName(), score.get(p2.getName()) + 2);
-                        System.out.println(p2.getName() +" > "+ p1.getName() + (cached ? " (cached)" : ""));
+                        System.out.println(p2.getName() +" > "+ p1.getName() + newMarker);
                     }
                     else
                     {
                         score.put(p1.getName(), score.get(p1.getName()) + 1);
                         score.put(p2.getName(), score.get(p2.getName()) + 1);
-                        System.out.println(p2.getName() +" = "+ p1.getName() + (cached ? " (cached)" : ""));
+                        System.out.println(p2.getName() +" = "+ p1.getName() + newMarker);
                     }
                 }
             }


### PR DESCRIPTION
Here's two more small patches:
- A change to the pairwise result output when using caching: old results are now unmarked, while new ones are marked with `(new)`. This makes updating the official rankings a bit easier.
- A minor fix to the (undocumented) instruction synonyms: the `CMP` instruction in this redcode variant skips the next instruction if the target instructions are _not_ equal, so its "'94-style" synonym should be `SNE`, not `SEQ`.
